### PR TITLE
Add support for left/right merge join node

### DIFF
--- a/js/parser.js
+++ b/js/parser.js
@@ -83,7 +83,7 @@ var is_operator = function (step) {
 // Redshift operators
 var R_SEQ_SCAN = /XN\s+(Seq\s+Scan)\s+on\s+(\w+)/i;
 var R_JOIN_LOOP = /XN\s+(Nested\s+Loop)\s+(\w+)/i;
-var R_JOIN_MERGE = /XN\s+(Merge\s+Join)\s+(\w+)/i;
+var R_JOIN_MERGE = /XN\s+(Merge\s+Join|Merge\s+Right\s+Join|Merge\s+Left\s+Join)\s+(\w+)/i;
 var R_JOIN_HASH = /XN\s+(Hash\s+Join|Hash\s+Right\s+Join|Hash\s+Left\s+Join|Hash\s+NOT\s+IN\sJoin)\s+(\w+)/i;
 var R_HASH = /XN\s+(Hash$)/i;
 var R_AGGR = /XN\s+(Aggregate$|HashAggregate|GroupAggregate)/i;


### PR DESCRIPTION
Adding support for left/right merge join nodes.

Example plan fragment:
```
...
   ->  XN Merge Left Join DS_DIST_NONE  (cost=0.00..101160998.80 rows=2560411136 width=130)
            Merge Cond: ("outer".composite_pk = "inner".composite_pk)
            ->  XN Merge Left Join DS_DIST_NONE  (cost=0.00..94758167.06 rows=2560411136 width=165)
                  Merge Cond: ("outer".composite_pk = "inner".composite_pk)
                  ->  XN Merge Left Join DS_DIST_NONE  (cost=0.00..69163936.27 rows=2560411136 width=130)
                        Merge Cond: ("outer".composite_pk = "inner".composite_pk)
...
```

